### PR TITLE
Add MP_ERROR_TEXT for MicroPython post-1.12 (esp32-only)

### DIFF
--- a/driver/esp32/modILI9341.c
+++ b/driver/esp32/modILI9341.c
@@ -184,12 +184,12 @@ STATIC void disp_spi_init(ILI9341_t *self)
 	//Initialize the SPI bus
 	ret=spi_bus_initialize(self->spihost, &buscfg, 1);
     if (ret != ESP_OK) nlr_raise(
-        mp_obj_new_exception_msg(&mp_type_RuntimeError, "Failed initializing SPI bus"));
+        mp_obj_new_exception_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Failed initializing SPI bus")));
 
 	//Attach the LCD to the SPI bus
 	ret=spi_bus_add_device(self->spihost, &devcfg, &self->spi);
     if (ret != ESP_OK) nlr_raise(
-        mp_obj_new_exception_msg(&mp_type_RuntimeError, "Failed adding SPI device"));
+        mp_obj_new_exception_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Failed adding SPI device")));
 }
 
 STATIC void disp_spi_send(ILI9341_t *self, const uint8_t * data, uint16_t length)

--- a/driver/esp32/modrtch.c
+++ b/driver/esp32/modrtch.c
@@ -314,7 +314,7 @@ STATIC mp_obj_t mp_rtch_init(mp_obj_t self_in)
         ESP_LOGE(TAG, "Failed createing RTCH task!");
         vTaskDelete(self->rtch_task_handle);
         nlr_raise(
-                mp_obj_new_exception_msg(&mp_type_RuntimeError, "Failed creating RTCH task"));
+                mp_obj_new_exception_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Failed creating RTCH task")));
     }
 
     ESP_LOGD(TAG, "RTCH Initialized");

--- a/driver/esp32/modxpt2046.c
+++ b/driver/esp32/modxpt2046.c
@@ -185,7 +185,7 @@ STATIC mp_obj_t mp_xpt2046_init(mp_obj_t self_in)
     //Attach the touch controller to the SPI bus
     ret=spi_bus_add_device(self->spihost, &devcfg, &self->spi);
     if (ret != ESP_OK) nlr_raise(
-        mp_obj_new_exception_msg(&mp_type_RuntimeError, "Failed adding SPI device"));
+        mp_obj_new_exception_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Failed adding SPI device")));
 
     return mp_const_none;
 }
@@ -211,7 +211,7 @@ static bool xpt2046_read(lv_indev_data_t * data)
     xpt2046_obj_t *self = MP_OBJ_TO_PTR(g_xpt2046 );
     if (!self || (!self->spi)) nlr_raise(
             mp_obj_new_exception_msg(
-                &mp_type_RuntimeError, "xpt2046 instance needs to be created before callback is called!"));
+                &mp_type_RuntimeError, MP_ERROR_TEXT("xpt2046 instance needs to be created before callback is called!")));
     static int16_t last_x = 0;
     static int16_t last_y = 0;
     bool valid = true;

--- a/driver/generic/modlvindev.c
+++ b/driver/generic/modlvindev.c
@@ -128,7 +128,7 @@ STATIC bool indev_read(lv_indev_data_t *data)
     indev_obj_t *self = MP_OBJ_TO_PTR(g_indev);
     if (!self || (!self->callback)) nlr_raise(
             mp_obj_new_exception_msg(
-                &mp_type_RuntimeError, "indev instance needs to be created before callback is called!"));
+                &mp_type_RuntimeError, MP_ERROR_TEXT("indev instance needs to be created before callback is called!")));
 
     mp_obj_t mp_ptr = NEW_PTR_OBJ(lv_indev_data_t, data);
     mp_obj_t mp_return_value = mp_call_function_n_kw(self->callback, 1, 0, &mp_ptr);

--- a/gen/gen_mpy.py
+++ b/gen/gen_mpy.py
@@ -547,7 +547,7 @@ STATIC mp_obj_t *cast(mp_obj_t *mp_obj, const mp_obj_type_t *mp_type)
     }
     if (res == NULL) nlr_raise(
         mp_obj_new_exception_msg_varg(
-            &mp_type_SyntaxError, "Can't convert %s to %s!", mp_obj_get_type_str(mp_obj), qstr_str(mp_type->name)));
+            &mp_type_SyntaxError, MP_ERROR_TEXT("Can't convert %s to %s!"), mp_obj_get_type_str(mp_obj), qstr_str(mp_type->name)));
     return res;
 }
 
@@ -665,7 +665,7 @@ STATIC inline mp_lv_struct_t *mp_to_lv_struct(mp_obj_t mp_obj)
     if (mp_obj == NULL || mp_obj == mp_const_none) return NULL;
     if (!MP_OBJ_IS_OBJ(mp_obj)) nlr_raise(
             mp_obj_new_exception_msg(
-                &mp_type_SyntaxError, "Struct argument is not an object!"));
+                &mp_type_SyntaxError, MP_ERROR_TEXT("Struct argument is not an object!")));
     mp_lv_struct_t *mp_lv_struct = MP_OBJ_TO_PTR(get_native_obj(mp_obj));
     return mp_lv_struct;
 }
@@ -685,7 +685,7 @@ STATIC mp_obj_t make_new_lv_struct(
     if ((!MP_OBJ_IS_TYPE(type, &mp_type_type)) || type->make_new != &make_new_lv_struct)
         nlr_raise(
             mp_obj_new_exception_msg(
-                &mp_type_SyntaxError, "Argument is not a struct type!"));
+                &mp_type_SyntaxError, MP_ERROR_TEXT("Argument is not a struct type!")));
     size_t size = get_lv_struct_size(type);
     mp_arg_check_num(n_args, n_kw, 0, 1, false);
     mp_lv_struct_t *self = m_new_obj(mp_lv_struct_t);
@@ -738,7 +738,7 @@ STATIC mp_obj_t dict_to_struct(mp_obj_t dict, const mp_obj_type_t *type)
             type->attr(mp_struct, mp_obj_str_get_qstr(key), dest);
             if (dest[0]) nlr_raise(
                 mp_obj_new_exception_msg_varg(
-                    &mp_type_SyntaxError, "Cannot set field %s on struct %s!", qstr_str(mp_obj_str_get_qstr(key)), qstr_str(type->name)));
+                    &mp_type_SyntaxError, MP_ERROR_TEXT("Cannot set field %s on struct %s!"), qstr_str(mp_obj_str_get_qstr(key)), qstr_str(type->name)));
         }
     }
     return mp_struct;
@@ -763,7 +763,7 @@ STATIC void* mp_to_ptr(mp_obj_t self_in)
             return MP_OBJ_TO_PTR(self_in);
         else nlr_raise(
                 mp_obj_new_exception_msg_varg(
-                    &mp_type_SyntaxError, "Cannot convert '%s' to pointer!", mp_obj_get_type_str(self_in)));
+                    &mp_type_SyntaxError, MP_ERROR_TEXT("Cannot convert '%s' to pointer!"), mp_obj_get_type_str(self_in)));
     }
 
     if (MP_OBJ_IS_STR_OR_BYTES(self_in) || 
@@ -776,7 +776,7 @@ STATIC void* mp_to_ptr(mp_obj_t self_in)
         if (buffer_info.len != sizeof(result) || buffer_info.typecode != BYTEARRAY_TYPECODE){
             nlr_raise(
                 mp_obj_new_exception_msg_varg(
-                    &mp_type_SyntaxError, "Cannot convert %s to pointer! (buffer does not represent a pointer)", mp_obj_get_type_str(self_in)));
+                    &mp_type_SyntaxError, MP_ERROR_TEXT("Cannot convert %s to pointer! (buffer does not represent a pointer)"), mp_obj_get_type_str(self_in)));
         }
         memcpy(&result, buffer_info.buf, sizeof(result));
         return result;
@@ -817,7 +817,7 @@ STATIC mp_obj_t mp_blob_cast(size_t argc, const mp_obj_t *argv)
     if (!MP_OBJ_IS_TYPE(type, &mp_type_type))
         nlr_raise(
             mp_obj_new_exception_msg(
-                &mp_type_SyntaxError, "Cast argument must be a type!"));
+                &mp_type_SyntaxError, MP_ERROR_TEXT("Cast argument must be a type!")));
     return cast(MP_OBJ_FROM_PTR(ptr), type);
 }
 


### PR DESCRIPTION
This PR has fixes needed post MicroPython v1.12 due to the required MP_ERROR_TEXT macro.
This PR only fixes the esp32 port, same changes need to happen for other ports as well..
I realize you don't want to just merge this given that you're most likely still working with v1.12, I'm just providing it for the future.