### PR TITLE
fix(stm32) skip lv_task_handler if scheduler queue is full

### DIFF
--- a/driver/stm32/lvstm32.py
+++ b/driver/stm32/lvstm32.py
@@ -21,7 +21,9 @@ class lvstm32():
     def timer_cb(self, t):
         lv.tick_inc(self.delay)
         # Passing self.task_handler would cause allocation.
-        micropython.schedule(self.task_handler_ref, 0)
+        try:
+            micropython.schedule(self.task_handler_ref, 0)
+        except RuntimeError:
+            pass
 
-      
 


### PR DESCRIPTION
This means that GUI ticks may be skipped on a busy system, but that is better than hanging the GUI forever.

Fixes #82.