### PR TITLE
Adding driver for Zephyr OS

### DIFF
--- a/driver/zephyr/README.md
+++ b/driver/zephyr/README.md
@@ -1,0 +1,53 @@
+## Zephyr driver for LV bindings project
+
+This driver allows Micropython with LVGL as an external C module to run as a Zephyr OS application; thus, all boards, display, and input drivers can be used from Zephyr's codebase.
+
+### Driver architecture
+This driver consist of three files:
+
+#### lvgl.c
+This file is taken from the Zephyr codebase and is adjusted for this use case. Display driver initialization is being done here.
+#### modlvzephyr.c
+This file provides a binding to the lv_init function, which needs to be called before using LVGL from Micropython.
+#### lvgl_driver.h
+In this file, the display driver and the input driver need to be defined. In addition, the display resolution has to be defined here.
+
+### Building the driver
+LV bindings project needs to be included as stated in the main README.
+To integrate the Zephyr driver, the following lines have to be inserted in Micropython's Zephyr port:
+* Include path of Micropython's build systems have to be added to the Makefile:
+```
+INC += -I$(ZEPHYR_BASE)
+INC += -I$(TOP)/lib/lv_bindings
+INC += -I$(TOP)/lib/lv_bindings/driver/zephyr
+INC += -I$(ZEPHYR_BASE)/include
+INC += -I$(ZEPHYR_BASE)/lib/gui/lvgl/
+INC += -I$(TOP)/lib/lv_bindings/lvgl
+```
+
+* Driver C files from Zephyr codebase need to be add for the build to the Makefile.
+```
+SRC_C +=  $(ZEPHYR_BASE)/lib/gui/lvgl/lvgl_display_16bit.c \
+    $(ZEPHYR_BASE)/lib/gui/lvgl/lvgl_display_24bit.c \
+    $(ZEPHYR_BASE)/lib/gui/lvgl/lvgl_display_32bit.c \
+    $(ZEPHYR_BASE)/lib/gui/lvgl/lvgl_display.c \
+    $(ZEPHYR_BASE)/lib/gui/lvgl/lvgl_display_mono.c \
+    build/lvgl/lv_mpy.c
+```
+* ```lvgl_driver.h``` has to be adjusted to specific board and display.
+* Display driver and input device driver need to be enabled in some project config, e.g., in your board .prj file. The following example is enabling the ELCDIF display driver and FT5336 input driver:
+```
+CONFIG_DISPLAY_MCUX_ELCDIF=y
+CONFIG_DISPLAY=y
+CONFIG_MCUX_ELCDIF_PANEL_RK043FN02H=y
+CONFIG_KSCAN=y
+CONFIG_KSCAN_FT5336=y
+```
+
+#### Usage
+LVGL and driver initialization is following:
+```
+import lvgl as lv
+import ZDD
+ZDD.init()
+```

--- a/driver/zephyr/README.md
+++ b/driver/zephyr/README.md
@@ -43,6 +43,19 @@ CONFIG_MCUX_ELCDIF_PANEL_RK043FN02H=y
 CONFIG_KSCAN=y
 CONFIG_KSCAN_FT5336=y
 ```
+* Link Zephyr kernel with MPY app, adding following line to Zepjyr's port CMakelists.txt:
+```
+target_link_libraries(libmicropython INTERFACE kernel)
+```
+* edit lv_conf.h:
+```
+#define LV_TICK_CUSTOM_INCLUDE      "kernel.h"
+#define LV_TICK_CUSTOM_SYS_TIME_EXPR    (k_uptime_get_32())
+
+typedef void *lv_disp_drv_user_data_t;
+typedef void *lv_indev_drv_user_data_t;
+
+```
 
 #### Usage
 LVGL and driver initialization is following:

--- a/driver/zephyr/README.md
+++ b/driver/zephyr/README.md
@@ -2,6 +2,11 @@
 
 This driver allows Micropython with LVGL as an external C module to run as a Zephyr OS application; thus, all boards, display, and input drivers can be used from Zephyr's codebase.
 
+### lv_micropython
+This driver is integrated for Micropython's Zephyr port build in the [lv_micropython project](https://github.com/lvgl/lv_micropython). Using the lv_micopython Zephyr port with LVGL requires:
+* specifying the display and input drivers in the your-board.prj and in the lvgl_driver.h
+* editing LV_TICK_CUSTOM_INCLUDE in lv_conf.h as stated below.
+
 ### Driver architecture
 This driver consist of three files:
 

--- a/driver/zephyr/lvgl.c
+++ b/driver/zephyr/lvgl.c
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2018-2019 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <init.h>
+#include <stdio.h>
+#include <zephyr.h>
+#include <lvgl.h>
+#include "lvgl_display.h"
+#include "lvgl_driver.h"
+#include <drivers/display.h>
+#ifdef CONFIG_LVGL_USE_FILESYSTEM
+#include "lvgl_fs.h"
+#endif
+#ifdef CONFIG_LVGL_POINTER_KSCAN
+#include <drivers/kscan.h>
+#endif
+#include LV_MEM_CUSTOM_INCLUDE
+
+#define LOG_LEVEL CONFIG_LVGL_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER(lvgl);
+
+#ifdef CONFIG_LVGL_BUFFER_ALLOC_STATIC
+
+lv_disp_buf_t disp_buf;
+
+#define BUFFER_SIZE (CONFIG_LVGL_BITS_PER_PIXEL * ((CONFIG_LVGL_VDB_SIZE * \
+			LV_HOR_RES_MAX * LV_VER_RES_MAX) / 100) / 8)
+
+#define NBR_PIXELS_IN_BUFFER (BUFFER_SIZE * 8 / CONFIG_LVGL_BITS_PER_PIXEL)
+
+/* NOTE: depending on chosen color depth buffer may be accessed using uint8_t *,
+ * uint16_t * or uint32_t *, therefore buffer needs to be aligned accordingly to
+ * prevent unaligned memory accesses.
+ */
+static uint8_t buf0[BUFFER_SIZE] __aligned(4);
+#ifdef CONFIG_LVGL_DOUBLE_VDB
+static uint8_t buf1[BUFFER_SIZE] __aligned(4);
+#endif
+
+#endif /* CONFIG_LVGL_BUFFER_ALLOC_STATIC */
+
+#if CONFIG_LVGL_LOG_LEVEL != 0
+static void lvgl_log(lv_log_level_t level, const char *file, uint32_t line,
+		const char *func, const char *dsc)
+{
+	/* Convert LVGL log level to Zephyr log level
+	 *
+	 * LVGL log level mapping:
+	 * * LV_LOG_LEVEL_TRACE 0
+	 * * LV_LOG_LEVEL_INFO  1
+	 * * LV_LOG_LEVEL_WARN  2
+	 * * LV_LOG_LEVEL_ERROR 3
+	 * * LV_LOG_LEVEL_NUM  4
+	 *
+	 * Zephyr log level mapping:
+	 * *  LOG_LEVEL_NONE 0
+	 * * LOG_LEVEL_ERR 1
+	 * * LOG_LEVEL_WRN 2
+	 * * LOG_LEVEL_INF 3
+	 * * LOG_LEVEL_DBG 4
+	 */
+	uint8_t zephyr_level = LOG_LEVEL_DBG - level;
+
+	ARG_UNUSED(file);
+	ARG_UNUSED(line);
+	ARG_UNUSED(func);
+
+	Z_LOG(zephyr_level, "%s", log_strdup(dsc));
+}
+#endif
+
+#ifdef CONFIG_LVGL_BUFFER_ALLOC_STATIC
+
+static int lvgl_allocate_rendering_buffers(lv_disp_drv_t *disp_drv)
+{
+	struct display_capabilities cap;
+	const struct device *display_dev = (const struct device *)disp_drv->user_data;
+	int err = 0;
+
+	display_get_capabilities(display_dev, &cap);
+
+	if (cap.x_resolution <= LV_HOR_RES_MAX) {
+		disp_drv->hor_res = cap.x_resolution;
+	} else {
+		printf("Horizontal resolution is larger than maximum");
+		err = -ENOTSUP;
+	}
+
+	if (cap.y_resolution <= LV_VER_RES_MAX) {
+		disp_drv->ver_res = cap.y_resolution;
+	} else {
+		printf("Vertical resolution is larger than maximum");
+		err = -ENOTSUP;
+	}
+
+	disp_drv->buffer = &disp_buf;
+#ifdef CONFIG_LVGL_DOUBLE_VDB
+	lv_disp_buf_init(disp_drv->buffer, &buf0, &buf1, NBR_PIXELS_IN_BUFFER);
+#else
+	lv_disp_buf_init(disp_drv->buffer, &buf0, NULL, NBR_PIXELS_IN_BUFFER);
+#endif /* CONFIG_LVGL_DOUBLE_VDB  */
+
+	return err;
+}
+
+#else
+
+static int lvgl_allocate_rendering_buffers(lv_disp_drv_t *disp_drv)
+{
+	void *buf0 = NULL;
+	void *buf1 = NULL;
+	uint16_t buf_nbr_pixels;
+	uint32_t buf_size;
+	struct display_capabilities cap;
+	const struct device *display_dev = (const struct device *)disp_drv->user_data;
+
+	display_get_capabilities(display_dev, &cap);
+
+	disp_drv->hor_res = cap.x_resolution;
+	disp_drv->ver_res = cap.y_resolution;
+
+	buf_nbr_pixels = (CONFIG_LVGL_VDB_SIZE * disp_drv->hor_res *
+			disp_drv->ver_res) / 100;
+	/* one horizontal line is the minimum buffer requirement for lvgl */
+	if (buf_nbr_pixels < disp_drv->hor_res) {
+		buf_nbr_pixels = disp_drv->hor_res;
+	}
+
+	switch (cap.current_pixel_format) {
+	case PIXEL_FORMAT_ARGB_8888:
+		buf_size = 4 * buf_nbr_pixels;
+		break;
+	case PIXEL_FORMAT_RGB_888:
+		buf_size = 3 * buf_nbr_pixels;
+		break;
+	case PIXEL_FORMAT_RGB_565:
+		buf_size = 2 * buf_nbr_pixels;
+		break;
+	case PIXEL_FORMAT_MONO01:
+	case PIXEL_FORMAT_MONO10:
+		buf_size = buf_nbr_pixels / 8;
+		buf_size += (buf_nbr_pixels % 8) == 0 ? 0 : 1;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	buf0 = LV_MEM_CUSTOM_ALLOC(buf_size);
+	if (buf0 == NULL) {
+		printf("Failed to allocate memory for rendering buffer");
+		return -ENOMEM;
+	}
+
+#ifdef CONFIG_LVGL_DOUBLE_VDB
+	buf1 = LV_MEM_CUSTOM_ALLOC(buf_size);
+	if (buf1 == NULL) {
+		LV_MEM_CUSTOM_FREE(buf0);
+		printf("Failed to allocate memory for rendering buffer");
+		return -ENOMEM;
+	}
+#endif
+
+	disp_drv->buffer = LV_MEM_CUSTOM_ALLOC(sizeof(lv_disp_buf_t));
+	if (disp_drv->buffer == NULL) {
+		LV_MEM_CUSTOM_FREE(buf0);
+		LV_MEM_CUSTOM_FREE(buf1);
+		printf("Failed to allocate memory to store rendering buffers");
+		return -ENOMEM;
+	}
+
+	lv_disp_buf_init(disp_drv->buffer, buf0, buf1, buf_nbr_pixels);
+	return 0;
+}
+#endif /* CONFIG_LVGL_BUFFER_ALLOC_STATIC */
+
+#ifdef CONFIG_LVGL_POINTER_KSCAN
+K_MSGQ_DEFINE(kscan_msgq, sizeof(lv_indev_data_t),
+	      CONFIG_LVGL_POINTER_KSCAN_MSGQ_COUNT, 4);
+
+static void lvgl_pointer_kscan_callback(const struct device *dev,
+					uint32_t row,
+					uint32_t col, bool pressed)
+{
+	lv_indev_data_t data = {
+		.point.x = col,
+		.point.y = row,
+		.state = pressed ? LV_INDEV_STATE_PR : LV_INDEV_STATE_REL,
+	};
+	int err = k_msgq_put(&kscan_msgq, &data, K_NO_WAIT);
+	if ( err != 0) {
+		printf("Could not put input data into queue, err: %d\n", err);
+	}
+}
+
+static bool lvgl_pointer_kscan_read(lv_indev_drv_t *drv, lv_indev_data_t *data)
+{
+	lv_disp_t *disp;
+	const struct device *disp_dev;
+	struct display_capabilities cap;
+	lv_indev_data_t curr;
+
+	static lv_indev_data_t prev = {
+		.point.x = 0,
+		.point.y = 0,
+		.state = LV_INDEV_STATE_REL,
+	};
+
+	if (k_msgq_get(&kscan_msgq, &curr, K_NO_WAIT) != 0) {
+		goto set_and_release;
+	}
+
+	prev = curr;
+
+	disp = lv_disp_get_default();
+	disp_dev = disp->driver.user_data;
+
+	display_get_capabilities(disp_dev, &cap);
+
+	/* adjust kscan coordinates */
+	if (IS_ENABLED(CONFIG_LVGL_POINTER_KSCAN_SWAP_XY)) {
+		lv_coord_t x;
+
+		x = prev.point.x;
+		prev.point.x = prev.point.y;
+		prev.point.y = x;
+	}
+
+	if (IS_ENABLED(CONFIG_LVGL_POINTER_KSCAN_INVERT_X)) {
+		if (cap.current_orientation == DISPLAY_ORIENTATION_NORMAL ||
+		    cap.current_orientation == DISPLAY_ORIENTATION_ROTATED_180) {
+			prev.point.x = cap.x_resolution - prev.point.x;
+		} else {
+			prev.point.x = cap.y_resolution - prev.point.x;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_LVGL_POINTER_KSCAN_INVERT_Y)) {
+		if (cap.current_orientation == DISPLAY_ORIENTATION_NORMAL ||
+		    cap.current_orientation == DISPLAY_ORIENTATION_ROTATED_180) {
+			prev.point.y = cap.y_resolution - prev.point.y;
+		} else {
+			prev.point.y = cap.x_resolution - prev.point.y;
+		}
+	}
+
+	/* rotate touch point to match display rotation */
+	if (cap.current_orientation == DISPLAY_ORIENTATION_ROTATED_90) {
+		lv_coord_t x;
+
+		x = prev.point.x;
+		prev.point.x = prev.point.y;
+		prev.point.y = cap.y_resolution - x;
+	} else if (cap.current_orientation == DISPLAY_ORIENTATION_ROTATED_180) {
+		prev.point.x = cap.x_resolution - prev.point.x;
+		prev.point.y = cap.y_resolution - prev.point.y;
+	} else if (cap.current_orientation == DISPLAY_ORIENTATION_ROTATED_270) {
+		lv_coord_t x;
+
+		x = prev.point.x;
+		prev.point.x = cap.x_resolution - prev.point.y;
+		prev.point.y = x;
+	}
+
+set_and_release:
+	*data = prev;
+
+	return k_msgq_num_used_get(&kscan_msgq) > 0;
+}
+
+static int lvgl_pointer_kscan_init(void)
+{
+	const struct device *kscan_dev =
+		device_get_binding(CONFIG_LVGL_POINTER_KSCAN_DEV_NAME);
+
+	lv_indev_drv_t indev_drv;
+
+	if (kscan_dev == NULL) {
+		printf("Keyboard scan device not found.");
+		return -ENODEV;
+	}
+
+	if (kscan_config(kscan_dev, lvgl_pointer_kscan_callback) < 0) {
+		printf("Could not configure keyboard scan device.");
+		return -ENODEV;
+	}
+
+	lv_indev_drv_init(&indev_drv);
+	indev_drv.type = LV_INDEV_TYPE_POINTER;
+	indev_drv.read_cb = lvgl_pointer_kscan_read;
+
+	if (lv_indev_drv_register(&indev_drv) == NULL) {
+		printf("Failed to register input device.");
+		return -EPERM;
+	}
+
+	int err = kscan_enable_callback(kscan_dev);
+	if (err != 0)
+		printf("callback enabling failed\n");
+
+	return 0;
+}
+#endif /* CONFIG_LVGL_POINTER_KSCAN */
+
+int lvgl_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	const struct device *display_dev =
+		device_get_binding(CONFIG_LVGL_DISPLAY_DEV_NAME);
+	int err = 0;
+	lv_disp_drv_t disp_drv;
+
+	if (display_dev == NULL) {
+		printf("Display device not found.");
+		return -ENODEV;
+	}
+
+#if CONFIG_LVGL_LOG_LEVEL != 0
+	lv_log_register_print_cb(lvgl_log);
+#endif
+
+	lv_init();
+
+#ifdef CONFIG_LVGL_USE_FILESYSTEM
+	lvgl_fs_init();
+#endif
+
+	lv_disp_drv_init(&disp_drv);
+	disp_drv.user_data = (void *) display_dev;
+
+	err = lvgl_allocate_rendering_buffers(&disp_drv);
+	if (err != 0) {
+		printf("Error alocate buffers\n");
+		return err;
+	}
+
+	if (set_lvgl_rendering_cb(&disp_drv) != 0) {
+		printf("Display not supported.\n");
+		return -ENOTSUP;
+	}
+
+	if (lv_disp_drv_register(&disp_drv) == NULL) {
+		printf("Failed to register display device.\n");
+		return -EPERM;
+	}
+
+#ifdef CONFIG_LVGL_POINTER_KSCAN
+	lvgl_pointer_kscan_init();
+#endif /* CONFIG_LVGL_POINTER_KSCAN */
+
+	return 0;
+}

--- a/driver/zephyr/lvgl_driver.h
+++ b/driver/zephyr/lvgl_driver.h
@@ -1,0 +1,10 @@
+#define CONFIG_LVGL_BITS_PER_PIXEL 32
+#define CONFIG_LVGL_VDB_SIZE 16
+#define CONFIG_LVGL_DISPLAY_DEV_NAME "ELCDIF_1" // choose from Zephyr display drivers
+#define CONFIG_LVGL_BUFFER_ALLOC_STATIC 1 // LVGL buffer settings, see other options in Zephyr's Kconfig
+#define CONFIG_LVGL_POINTER_KSCAN 0 // enabling/disabling kernel scan for input queue
+#define CONFIG_LVGL_POINTER_KSCAN_MSGQ_COUNT 10
+#define CONFIG_LVGL_POINTER_KSCAN_DEV_NAME "FT5336" // choose from Zephyr input drivers
+
+
+int lvgl_init(const struct device *dev);

--- a/driver/zephyr/lvgl_driver.h
+++ b/driver/zephyr/lvgl_driver.h
@@ -2,7 +2,7 @@
 #define CONFIG_LVGL_VDB_SIZE 16
 #define CONFIG_LVGL_DISPLAY_DEV_NAME "ELCDIF_1" // choose from Zephyr display drivers
 #define CONFIG_LVGL_BUFFER_ALLOC_STATIC 1 // LVGL buffer settings, see other options in Zephyr's Kconfig
-#define CONFIG_LVGL_POINTER_KSCAN 0 // enabling/disabling kernel scan for input queue
+#define CONFIG_LVGL_POINTER_KSCAN 1 // enabling/disabling kernel scan for input queue
 #define CONFIG_LVGL_POINTER_KSCAN_MSGQ_COUNT 10
 #define CONFIG_LVGL_POINTER_KSCAN_DEV_NAME "FT5336" // choose from Zephyr input drivers
 

--- a/driver/zephyr/modlvzephyr.c
+++ b/driver/zephyr/modlvzephyr.c
@@ -1,0 +1,21 @@
+#include "py/runtime.h"
+#include "lvgl_driver.h"
+
+STATIC mp_obj_t init() {
+	lvgl_init(NULL);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(init_obj, init);
+
+STATIC const mp_rom_map_elem_t ZDD_module_globals_table[] = {
+	{ MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ZDD) },
+    { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&init_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(ZDD_module_globals, ZDD_module_globals_table);
+
+const mp_obj_module_t ZDD_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&ZDD_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_ZDD, ZDD_user_cmodule, 1);


### PR DESCRIPTION
This PR introduces a driver for Zephyr OS so that Micropython+LVGL could be used as a Zephyr application.
More information is in the enclosed README.

The lvgl.c file is taken from the Zephyr codebase and adjusted for this use case.

The PR was tested on i.MX RT1050, with ELCDIF display driver and FT5336 input driver from Zephyr OS.

Edit:
Zephyr already supports LVGL (in C language) - driver abstraction layer is available in Zephyr codebase and LVGL as a Zephyr's module can be enabled with Kconfig.

For Zephyr + Micropython + LVGL use case are LVGL source files taken from the LV bindings project; thus LVGL has to be disabled in Zephyr's Kconfig configuration in order to prevent redefinitions. The reason is, that LVGL should in this use case use Micorpython's memory functions and not Zephyr's, so it seemed more appropriate to preserve LVGL + Micropython and not LVGL + Zephyr connection.