### PR TITLE
Use tree_walk in CI tests

### DIFF
--- a/examples/custom_widget_example.py
+++ b/examples/custom_widget_example.py
@@ -5,6 +5,9 @@
 # Initializations
 ##############################################################################
 
+import sys
+sys.path.append('') # See: https://github.com/micropython/micropython/issues/6419
+
 import lvgl as lv
 import display_driver
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -10,5 +10,5 @@ EXCLUDE_PATH="$SCRIPT_PATH/../examples/fb_test.py $SCRIPT_PATH/../examples/uasyn
 EXCLUDE_FINDEXP=$(echo $EXCLUDE_PATH | sed "s/^\|[[:space:]]/ -and -not -path /g")
 
 find $TEST_PATH -name "*.py" $EXCLUDE_FINDEXP |\
-   xargs -I {} timeout 5 $SCRIPT_PATH/../../../ports/unix/micropython-dev $SCRIPT_PATH/run_test.py {}
+   xargs -I {} timeout 5m $SCRIPT_PATH/../../../ports/unix/micropython-dev $SCRIPT_PATH/run_test.py {}
 


### PR DESCRIPTION
- Traverse all objects under active screen and send each of them the following events: lv.EVENT.SCROLL, lv.EVENT.CLICKED, lv.EVENT.VALUE_CHANGED, lv.EVENT.READY
- Limit events to 100 sibling child objects because events could triggger the creation of more child objects and cause infinite loop
- Decrease delay to 25ms and increase test timeout to 5 minutes
- During traversal print label text and widgets values when applicable (for debugging)

Waiting for https://github.com/lvgl/lvgl/pull/2354 to be merged, to fix a few small problems in the examples.


