### PR TITLE
CI: Catch SIGSEGV when running tests

### DIFF
--- a/.github/workflows/unix_port.yml
+++ b/.github/workflows/unix_port.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build mpy-cross
       run: make -j $(nproc) -C mpy-cross
     - name: Build the unix port
-      run: make -j $(nproc) -C ports/unix VARIANT=dev DEBUG=1 LDFLAGS_MOD=-rdynamic
+      run: make -j $(nproc) -C ports/unix VARIANT=dev DEBUG=1 LDFLAGS_MOD="-rdynamic -ldl"
     - name: Run tests
       run: lib/lv_bindings/tests/run.sh
 

--- a/.github/workflows/unix_port.yml
+++ b/.github/workflows/unix_port.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build mpy-cross
       run: make -j $(nproc) -C mpy-cross
     - name: Build the unix port
-      run: make -j $(nproc) -C ports/unix VARIANT=dev DEBUG=1
+      run: make -j $(nproc) -C ports/unix VARIANT=dev DEBUG=1 LDFLAGS_MOD=-rdynamic
     - name: Run tests
       run: lib/lv_bindings/tests/run.sh
 

--- a/.github/workflows/unix_port.yml
+++ b/.github/workflows/unix_port.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build mpy-cross
       run: make -j $(nproc) -C mpy-cross
     - name: Build the unix port
-      run: make -j $(nproc) -C ports/unix VARIANT=dev DEBUG=1 LDFLAGS_MOD="-rdynamic -ldl"
+      run: make -j $(nproc) -C ports/unix VARIANT=dev DEBUG=1 LDFLAGS_MOD="-rdynamic -ldl -Wl,--copy-dt-needed-entries"
     - name: Run tests
       run: lib/lv_bindings/tests/run.sh
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -10,5 +10,5 @@ EXCLUDE_PATH="$SCRIPT_PATH/../examples/fb_test.py $SCRIPT_PATH/../examples/uasyn
 EXCLUDE_FINDEXP=$(echo $EXCLUDE_PATH | sed "s/^\|[[:space:]]/ -and -not -path /g")
 
 find $TEST_PATH -name "*.py" $EXCLUDE_FINDEXP |\
-   xargs -I {} timeout 5m $SCRIPT_PATH/../../../ports/unix/micropython-dev $SCRIPT_PATH/run_test.py {}
+   xargs -I {} timeout 5m catchsegv $SCRIPT_PATH/../../../ports/unix/micropython-dev $SCRIPT_PATH/run_test.py {}
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -5,7 +5,7 @@ set -e # Exit on error
 SCRIPT_PATH="`dirname \"$0\"`"
 
 TEST_PATH="$SCRIPT_PATH/../examples/*.py $SCRIPT_PATH/../lvgl/examples/"
-EXCLUDE_PATH="$SCRIPT_PATH/../examples/fb_test.py $SCRIPT_PATH/../examples/uasyncio*.py"
+EXCLUDE_PATH="$SCRIPT_PATH/../examples/fb_test.py $SCRIPT_PATH/../examples/uasyncio*.py $SCRIPT_PATH/../examples/advanced_demo.py"
 
 EXCLUDE_FINDEXP=$(echo $EXCLUDE_PATH | sed "s/^\|[[:space:]]/ -and -not -path /g")
 


### PR DESCRIPTION
To debug random crashes, catch SIGSEGV and print stack trace when running tests.  

Example of a random crash: https://github.com/lvgl/lvgl/runs/3013533718?check_suite_focus=true
Related: https://github.com/lvgl/lvgl/pull/2358#issuecomment-875968344