### PR TITLE
Add fake lv_timer implementation for the JS port

### DIFF
--- a/driver/js/lv_timer.py
+++ b/driver/js/lv_timer.py
@@ -1,0 +1,21 @@
+# Stub Timer implementation for the JS port.
+#
+# This does absolutely nothing beyond provide a class, so it will
+# not be suitable for any application which needs a timer.
+#
+# MIT license; Copyright (c) 2021 embeddedt
+
+
+class Timer:
+
+    PERIODIC = 0
+    ONE_SHOT = 1
+
+    def __init__(self, id):
+        pass
+
+    def init(self, mode=PERIODIC, period=-1, callback=None):
+        pass
+
+    def deinit(self):
+        pass

--- a/lib/display_driver_utils.py
+++ b/lib/display_driver_utils.py
@@ -2,7 +2,8 @@ import usys as sys
 sys.path.append('') # See: https://github.com/micropython/micropython/issues/6419
 
 import lvgl as lv
-import lv_utils
+if sys.platform != 'javascript':
+    import lv_utils
 
 lv.init()
 
@@ -18,14 +19,15 @@ class driver:
         self.disp = None
         self.touch = None
         self.type = None
-        if not lv_utils.event_loop.is_running():
+        if sys.platform == 'javascript' or not lv_utils.event_loop.is_running():
             self.init_gui()
         
     def init_gui_SDL(self):
 
         import SDL
         SDL.init(w=self.width, h=self.height, auto_refresh=False)
-        self.event_loop = lv_utils.event_loop(refresh_cb = SDL.refresh)
+        if sys.platform != 'javascript':
+            self.event_loop = lv_utils.event_loop(refresh_cb = SDL.refresh)
 
         # Register SDL display driver.
 

--- a/lib/display_driver_utils.py
+++ b/lib/display_driver_utils.py
@@ -2,8 +2,7 @@ import usys as sys
 sys.path.append('') # See: https://github.com/micropython/micropython/issues/6419
 
 import lvgl as lv
-if sys.platform != 'javascript':
-    import lv_utils
+import lv_utils
 
 lv.init()
 
@@ -19,15 +18,14 @@ class driver:
         self.disp = None
         self.touch = None
         self.type = None
-        if sys.platform == 'javascript' or not lv_utils.event_loop.is_running():
+        if not lv_utils.event_loop.is_running():
             self.init_gui()
         
     def init_gui_SDL(self):
 
         import SDL
         SDL.init(w=self.width, h=self.height, auto_refresh=False)
-        if sys.platform != 'javascript':
-            self.event_loop = lv_utils.event_loop(refresh_cb = SDL.refresh)
+        self.event_loop = lv_utils.event_loop(refresh_cb = SDL.refresh)
 
         # Register SDL display driver.
 


### PR DESCRIPTION
`lv_utils` is not compatible with the JS port, as it does not have a Timer implementation.

It's also not needed as I use a custom event loop which is not configurable.