### PR TITLE
imagetools.py: bugfix for lv.canvas()

### DIFF
--- a/lib/imagetools.py
+++ b/lib/imagetools.py
@@ -37,7 +37,11 @@ def get_png_info(decoder, src, header):
     if lv.img.src_get_type(src) != lv.img.SRC.VARIABLE:
         return lv.RES.INV
 
-    png_header = bytes(lv.img_dsc_t.__cast__(src).data.__dereference__(24))
+    data = lv.img_dsc_t.__cast__(src).data
+    if data == None:
+        return lv.RES.INV
+    
+    png_header = bytes(data.__dereference__(24))
 
     if png_header.startswith(b'\211PNG\r\n\032\n'):
         if png_header[12:16] == b'IHDR':


### PR DESCRIPTION
If PNG decoder is initialized (using `imagetools.py`), then `lv.canvas()` throws `AttributeError: 'NoneType' object has no attribute '__dereference__'` exception in this line:
`png_header = bytes(lv.img_dsc_t.__cast__(src).data.__dereference__(24))`

So, basically do the following:
1. init PNG decoder
2. show a PNG image
3. initialize a canvas: `lv.canvas(lv.scr_act())`