### PR TITLE
Catch exceptions from task_handler in asynchronous loop

### DIFF
--- a/lib/lv_utils.py
+++ b/lib/lv_utils.py
@@ -138,7 +138,11 @@ class event_loop():
         while True:
             await self.refresh_event.wait()
             self.refresh_event.clear()
-            lv.task_handler()
+            try:
+                lv.task_handler()
+            except Exception as e:
+                if self.exception_sink:
+                    self.exception_sink(e)
             if self.refresh_cb: self.refresh_cb()
 
     async def async_timer(self):


### PR DESCRIPTION
Add missing try and except clauses to catch and pass exceptions from lv.task_handler() into exception_sink when using asynchronous loop.