### PR TITLE
Fix error caused by librt not existing for newer glibc versions

### DIFF
--- a/driver/linux/lv_timer.py
+++ b/driver/linux/lv_timer.py
@@ -16,7 +16,11 @@ import sys
 # FFI libraries
 
 libc = ffi.open("libc.so.6")
-librt = ffi.open("librt.so")
+try:
+    librt = ffi.open("librt.so")
+except OSError as e:
+    librt = libc
+
 
 # C constants
 


### PR DESCRIPTION
I'm using Arch Linux nowadays, which uses a very new glibc. It seems that recently `librt.so` and some other libraries were merged into `libc.so` and replaced by stubs ([source](https://sourceware.org/pipermail/libc-alpha/2021-August/129718.html)). Unfortunately, it doesn't appear that a stub for `librt.so` exists, and if it does, it is not compatible with Micropython's FFI for some reason.

Using the value of `libc` when `librt.so` does not exist seems to be a valid workaround, which is what I'm proposing here.