### PR TITLE
Generic/ili9341 Driver

### DIFF
--- a/driver/generic/ili9xxx-test.py
+++ b/driver/generic/ili9xxx-test.py
@@ -1,3 +1,5 @@
+import time
+
 from machine import SPI, Pin
 
 from ili9xxx import Ili9341_hw

--- a/driver/generic/ili9xxx-test.py
+++ b/driver/generic/ili9xxx-test.py
@@ -1,0 +1,48 @@
+from machine import SPI, Pin
+
+from ili9xxx import Ili9341_hw
+
+
+def build_rect_buf(w, h, inner=[0x00, 0x00]):
+    top = b"\xFF\xFF" * w
+    body = (b"\xFF\xFF\xFF" + bytes(inner) * (w - 3) + b"\xFF\xFF\xFF") * (h - 3)
+    bot = b"\xFF\xFF" * w
+    return top + body + bot
+
+
+spi = SPI(
+    0,
+    baudrate=24_000_000,
+    sck=Pin(18),
+    mosi=Pin(19),
+    miso=Pin(16),
+)
+lcd = Ili9341_hw(spi=spi, cs=17, dc=15, rst=14)
+
+lcd.set_backlight(30)
+for rot in (0, 1, 2, 3):
+    lcd.apply_rotation(rot)
+
+    lcd.clear(0x0000)
+    # 1/4 screen pixels square with white border red backgorund
+    w, h = lcd.width // 4, lcd.height // 8
+    bmp = build_rect_buf(w, h, [0x03, 0x03])
+    t0 = time.ticks_us()
+    lcd.blit(w, h, w, h, bmp)
+    t1 = time.ticks_us()
+    bmp = build_rect_buf(lcd.width, lcd.height // 20, [0x09, 0x09])
+    lcd.blit(0, 0, lcd.width, lcd.height // 20, bmp)
+
+    print("Maximum FPS @24MHz:", 24e6 / (320 * 240 * 16))  # FPS = F/(W*H*BPP)
+    print(
+        "Achieved FPS:", 1 / (16 * (t1 - t0) * 1e-6)
+    )  # Note: Test only draws 1/16 of the sreen area
+
+    print("Draw TSC calibration pattern")
+    w, h, wu, hu = lcd.width // 10, lcd.height // 10, lcd.width // 5, lcd.height // 5
+    bmp = build_rect_buf(w, h, [0xA0, 0xF0])
+    lcd.blit(wu, hu, w, h, bmp)
+    lcd.blit(4 * wu, hu, w, h, bmp)
+    lcd.blit(4 * wu, 4 * hu, w, h, bmp)
+    lcd.blit(wu, 4 * hu, w, h, bmp)
+    time.sleep(0.5)

--- a/driver/generic/ili9xxx.py
+++ b/driver/generic/ili9xxx.py
@@ -1,0 +1,148 @@
+from micropython import const
+
+from .st77xx import St77xx_hw, St77xx_lvgl
+
+# Command constants from ILI9341 datasheet
+_NOP = const(0x00)  # No-op
+_SWRESET = const(0x01)  # Software reset
+_RDDID = const(0x04)  # Read display ID info
+_RDDST = const(0x09)  # Read display status
+_SLPIN = const(0x10)  # Enter sleep mode
+_SLPOUT = const(0x11)  # Exit sleep mode
+_PTLON = const(0x12)  # Partial mode on
+_NORON = const(0x13)  # Normal display mode on
+_RDMODE = const(0x0A)  # Read display power mode
+_RDMADCTL = const(0x0B)  # Read display MADCTL
+_RDPIXFMT = const(0x0C)  # Read display pixel format
+_RDIMGFMT = const(0x0D)  # Read display image format
+_RDSELFDIAG = const(0x0F)  # Read display self-diagnostic
+_INVOFF = const(0x20)  # Display inversion off
+_INVON = const(0x21)  # Display inversion on
+_GAMMASET = const(0x26)  # Gamma set
+_DISPLAY_OFF = const(0x28)  # Display off
+_DISPLAY_ON = const(0x29)  # Display on
+_SET_COLUMN = const(0x2A)  # Column address set
+_SET_PAGE = const(0x2B)  # Page address set
+_WRITE_RAM = const(0x2C)  # Memory write
+_READ_RAM = const(0x2E)  # Memory read
+_PTLAR = const(0x30)  # Partial area
+_VSCRDEF = const(0x33)  # Vertical scrolling definition
+_MADCTL = const(0x36)  # Memory access control
+_VSCRSADD = const(0x37)  # Vertical scrolling start address
+_PIXFMT = const(0x3A)  # COLMOD: Pixel format set
+_WRITE_DISPLAY_BRIGHTNESS = const(0x51)  # Brightness hardware dependent!
+_READ_DISPLAY_BRIGHTNESS = const(0x52)
+_WRITE_CTRL_DISPLAY = const(0x53)
+_READ_CTRL_DISPLAY = const(0x54)
+_WRITE_CABC = const(0x55)  # Write Content Adaptive Brightness Control
+_READ_CABC = const(0x56)  # Read Content Adaptive Brightness Control
+_WRITE_CABC_MINIMUM = const(0x5E)  # Write CABC Minimum Brightness
+_READ_CABC_MINIMUM = const(0x5F)  # Read CABC Minimum Brightness
+_FRMCTR1 = const(0xB1)  # Frame rate control (In normal mode/full colors)
+_FRMCTR2 = const(0xB2)  # Frame rate control (In idle mode/8 colors)
+_FRMCTR3 = const(0xB3)  # Frame rate control (In partial mode/full colors)
+_INVCTR = const(0xB4)  # Display inversion control
+_DFUNCTR = const(0xB6)  # Display function control
+_PWCTR1 = const(0xC0)  # Power control 1
+_PWCTR2 = const(0xC1)  # Power control 2
+_PWCTRA = const(0xCB)  # Power control A
+_PWCTRB = const(0xCF)  # Power control B
+_VMCTR1 = const(0xC5)  # VCOM control 1
+_VMCTR2 = const(0xC7)  # VCOM control 2
+_RDID1 = const(0xDA)  # Read ID 1
+_RDID2 = const(0xDB)  # Read ID 2
+_RDID3 = const(0xDC)  # Read ID 3
+_RDID4 = const(0xDD)  # Read ID 4
+_GMCTRP1 = const(0xE0)  # Positive gamma correction
+_GMCTRN1 = const(0xE1)  # Negative gamma correction
+_DTCA = const(0xE8)  # Driver timing control A
+_DTCB = const(0xEA)  # Driver timing control B
+_POSC = const(0xED)  # Power on sequence control
+_ENABLE3G = const(0xF2)  # Enable 3 gamma control
+_PUMPRC = const(0xF7)  # Pump ratio control
+
+_MADCTL_MY = const(0x80)  # page address order (0: top to bottom; 1: bottom to top)
+_MADCTL_MX = const(0x40)  # column address order (0: left to right; 1: right to left)
+_MADCTL_MV = const(0x20)  # page/column order (0: normal mode 1; reverse mode)
+_MADCTL_ML = const(
+    0x10
+)  # line address order (0: refresh to to bottom; 1: refresh bottom to top)
+_MADCTL_BGR = const(0x08)  # colors are BGR (not RGB)
+_MADCTL_RTL = const(0x04)  # refresh right to left
+
+_MADCTL_ROTS = (
+    const(_MADCTL_MX),  # 0 = portrait
+    const(_MADCTL_MV),  # 1 = landscape
+    const(_MADCTL_MY),  # 2 = inverted portrait
+    const(_MADCTL_MX | _MADCTL_MY | _MADCTL_MV),  # 3 = inverted landscape
+)
+
+
+class Ili9341_hw(St77xx_hw):
+    def __init__(self, res, **kw):
+        super().__init__(
+            res=res,
+            suppRes=[
+                (240, 320),
+            ],
+            model=None,
+            suppModel=None,
+            bgr=True,
+            **kw,
+        )
+
+    def config_hw(self):
+        self._run_seq(
+            [
+                (_SLPOUT, None, 100),
+                (_PWCTRB, b"\x00\xC1\x30"),  # Pwr ctrl B
+                (_POSC, b"\x64\x03\x12\x81"),  # Pwr on seq. ctrl
+                (_DTCA, b"\x85\x00\x78"),  # Driver timing ctrl A
+                (_PWCTRA, b"\x39\x2C\x00\x34\x02"),  # Pwr ctrl A
+                (_PUMPRC, b"\x20"),  # Pump ratio control
+                (_DTCB, b"\x00\x00"),  # Driver timing ctrl B
+                (_PWCTR1, b"\x23"),  # Pwr ctrl 1
+                (_PWCTR2, b"\x10"),  # Pwr ctrl 2
+                (_VMCTR1, b"\x3E\x28"),  # VCOM ctrl 1
+                (_VMCTR2, b"\x86"),  # VCOM ctrl 2
+                # (_MADCTL, self.rotation"),  # Memory access ctrl  # TODO: rotation?
+                (_VSCRSADD, b"\x00"),  # Vertical scrolling start address
+                (_PIXFMT, b"\x55"),  # COLMOD: Pixel format
+                (_FRMCTR1, b"\x00\x18"),  # Frame rate ctrl
+                (_DFUNCTR, b"\x08\x82\x27"),
+                (_ENABLE3G, b"\x00"),  # Enable 3 gamma ctrl
+                (_GAMMASET, b"\x01"),  # Gamma curve selected
+                (
+                    _GMCTRP1,
+                    b"\x0F\x31\x2B\x0C\x0E\x08\x4E\xF1\x37\x07\x10\x03\x0E\x09\x00",
+                ),
+                (
+                    _GMCTRN1,
+                    b"\x00\x0E\x14\x03\x11\x07\x31\xC1\x48\x08\x0F\x0C\x31\x36\x0F",
+                ),
+                (_SLPOUT, None, 100),
+                (_DISPLAY_ON, None),
+            ]
+        )
+
+    def apply_rotation(self, rot):
+        self.rot = rot
+        if (self.rot % 2) == 0:
+            self.width, self.height = self.res
+        else:
+            self.height, self.width = self.res
+        self.write_register(
+            _MADCTL,
+            bytes([(_MADCTL_BGR if self.bgr else 0) | _MADCTL_ROTS[self.rot % 4]]),
+        )
+
+
+class Ili9341(Ili9341_hw, St77xx_lvgl):
+    def __init__(self, res, doublebuffer=True, factor=4, **kw):
+        """See :obj:`Ili9341_hw` for the meaning of the parameters."""
+        import lvgl as lv
+
+        Ili9341_hw.__init__(self, res=res, **kw)
+        St77xx_lvgl.__init__(self, doublebuffer, factor)
+        self.disp_drv.color_format = lv.COLOR_FORMAT.NATIVE_REVERSE
+        self.disp_drv.register()

--- a/driver/generic/ili9xxx.py
+++ b/driver/generic/ili9xxx.py
@@ -112,7 +112,7 @@ class Ili9341_hw(st77xx.St77xx_hw):
             ],
             model=None,
             suppModel=None,
-            bgr=True,
+            bgr=False,
             **kw,
         )
 
@@ -130,7 +130,6 @@ class Ili9341_hw(st77xx.St77xx_hw):
                 (_PWCTR2, b"\x10"),  # Pwr ctrl 2
                 (_VMCTR1, b"\x3E\x28"),  # VCOM ctrl 1
                 (_VMCTR2, b"\x86"),  # VCOM ctrl 2
-                # (_MADCTL, self.rotation"),  # Memory access ctrl  # TODO: rotation?
                 (_VSCRSADD, b"\x00"),  # Vertical scrolling start address
                 (_PIXFMT, b"\x55"),  # COLMOD: Pixel format
                 (_FRMCTR1, b"\x00\x18"),  # Frame rate ctrl
@@ -158,7 +157,7 @@ class Ili9341_hw(st77xx.St77xx_hw):
             self.height, self.width = self.res
         self.write_register(
             _MADCTL,
-            bytes([(_MADCTL_BGR if self.bgr else 0) | _MADCTL_ROTS[self.rot % 4]]),
+            bytes([_MADCTL_BGR | _MADCTL_ROTS[self.rot % 4]]),
         )
 
 
@@ -169,5 +168,3 @@ class Ili9341(Ili9341_hw, st77xx.St77xx_lvgl):
 
         Ili9341_hw.__init__(self, **kw)
         st77xx.St77xx_lvgl.__init__(self, doublebuffer, factor)
-        self.disp_drv.color_format = lv.COLOR_FORMAT.NATIVE_REVERSE
-        self.disp_drv.register()

--- a/driver/generic/ili9xxx.py
+++ b/driver/generic/ili9xxx.py
@@ -9,6 +9,7 @@ TODO:
     * Usage information.
 """
 from micropython import const
+
 from st77xx import St77xx_hw, St77xx_lvgl
 
 # Command constants from ILI9341 datasheet
@@ -93,13 +94,13 @@ ILI9XXX_INV_LANDSCAPE = const(3)
 
 
 class Ili9341_hw(St77xx_hw):
-    def __init__(self, res, **kw):
+    def __init__(self, **kw):
         """ILI9341 TFT Display Driver.
 
         Requires ``LV_COLOR_DEPTH=16`` when building lv_micropython to function.
         """
         super().__init__(
-            res=res,
+            res=(240, 320),
             suppRes=[
                 (240, 320),
             ],
@@ -156,11 +157,11 @@ class Ili9341_hw(St77xx_hw):
 
 
 class Ili9341(Ili9341_hw, St77xx_lvgl):
-    def __init__(self, res, doublebuffer=True, factor=4, **kw):
+    def __init__(self, doublebuffer=True, factor=4, **kw):
         """See :obj:`Ili9341_hw` for the meaning of the parameters."""
         import lvgl as lv
 
-        Ili9341_hw.__init__(self, res=res, **kw)
+        Ili9341_hw.__init__(self, **kw)
         St77xx_lvgl.__init__(self, doublebuffer, factor)
         self.disp_drv.color_format = lv.COLOR_FORMAT.NATIVE_REVERSE
         self.disp_drv.register()

--- a/driver/generic/ili9xxx.py
+++ b/driver/generic/ili9xxx.py
@@ -10,7 +10,7 @@ TODO:
 """
 from micropython import const
 
-from st77xx import St77xx_hw, St77xx_lvgl
+import st77xx
 
 # Command constants from ILI9341 datasheet
 _NOP = const(0x00)  # No-op
@@ -87,13 +87,13 @@ _MADCTL_ROTS = (
     const(_MADCTL_MX | _MADCTL_MY | _MADCTL_MV),  # 3 = inverted landscape
 )
 
-ILI9XXX_PORTRAIT = const(0)
-ILI9XXX_LANDSCAPE = const(1)
-ILI9XXX_INV_PORTRAIT = const(2)
-ILI9XXX_INV_LANDSCAPE = const(3)
+ILI9XXX_PORTRAIT = st77xx.ST77XX_PORTRAIT
+ILI9XXX_LANDSCAPE = st77xx.ST77XX_LANDSCAPE
+ILI9XXX_INV_PORTRAIT = st77xx.ST77XX_INV_PORTRAIT
+ILI9XXX_INV_LANDSCAPE = st77xx.ST77XX_INV_LANDSCAPE
 
 
-class Ili9341_hw(St77xx_hw):
+class Ili9341_hw(st77xx.St77xx_hw):
     def __init__(self, **kw):
         """ILI9341 TFT Display Driver.
 
@@ -156,12 +156,12 @@ class Ili9341_hw(St77xx_hw):
         )
 
 
-class Ili9341(Ili9341_hw, St77xx_lvgl):
+class Ili9341(Ili9341_hw, st77xx.St77xx_lvgl):
     def __init__(self, doublebuffer=True, factor=4, **kw):
         """See :obj:`Ili9341_hw` for the meaning of the parameters."""
         import lvgl as lv
 
         Ili9341_hw.__init__(self, **kw)
-        St77xx_lvgl.__init__(self, doublebuffer, factor)
+        st77xx.St77xx_lvgl.__init__(self, doublebuffer, factor)
         self.disp_drv.color_format = lv.COLOR_FORMAT.NATIVE_REVERSE
         self.disp_drv.register()

--- a/driver/generic/ili9xxx.py
+++ b/driver/generic/ili9xxx.py
@@ -5,8 +5,14 @@ This code is licensed under MIT license.
 Adapted from:
     https://github.com/rdagger/micropython-ili9341
 
-TODO:
-    * Usage information.
+The following code snippet will instantiate the driver and
+automatically register it to lvgl. Adjust the SPI bus and
+pin configurations to match your hardware setup::
+
+    import ili9xxx
+    from machine import SPI, Pin
+    spi = SPI(0, baudrate=24_000_000, sck=Pin(18), mosi=Pin(19), miso=Pin(16))
+    drv = ili9xxx.Ili9341(spi=spi, dc=15, cs=17, rst=14)
 """
 from micropython import const
 

--- a/driver/generic/ili9xxx.py
+++ b/driver/generic/ili9xxx.py
@@ -1,6 +1,15 @@
-from micropython import const
+"""Generic ILI9xxx drivers.
 
-from .st77xx import St77xx_hw, St77xx_lvgl
+This code is licensed under MIT license.
+
+Adapted from:
+    https://github.com/rdagger/micropython-ili9341
+
+TODO:
+    * Usage information.
+"""
+from micropython import const
+from st77xx import St77xx_hw, St77xx_lvgl
 
 # Command constants from ILI9341 datasheet
 _NOP = const(0x00)  # No-op
@@ -77,9 +86,18 @@ _MADCTL_ROTS = (
     const(_MADCTL_MX | _MADCTL_MY | _MADCTL_MV),  # 3 = inverted landscape
 )
 
+ILI9XXX_PORTRAIT = const(0)
+ILI9XXX_LANDSCAPE = const(1)
+ILI9XXX_INV_PORTRAIT = const(2)
+ILI9XXX_INV_LANDSCAPE = const(3)
+
 
 class Ili9341_hw(St77xx_hw):
     def __init__(self, res, **kw):
+        """ILI9341 TFT Display Driver.
+
+        Requires ``LV_COLOR_DEPTH=16`` when building lv_micropython to function.
+        """
         super().__init__(
             res=res,
             suppRes=[


### PR DESCRIPTION
Here's a working generic driver for the ILI9341 chip. I couldn't figure out how to get the rp2_dma stuff working in general, but if it works for the `St77xx` chips, I imagine it would also work for this one.