### PR TITLE
Chris jones79 patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The callback will receive a Blob which can be casted to the dict in the last arg
 
 As long as the convention above is followed, the lvgl Micropython binding script would automatically set and use `user_data` when callbacks are set and used.
 
-From the user perspective, any python callable object (such as python regular function, class function, lambda etc.) can be user as an lvgl callbacks. For example:
+From the user perspective, any python callable object (such as python regular function, class function, lambda etc.) can be used as an lvgl callbacks. For example:
 ```python
 lvgl.anim_set_custom_exec_cb(anim, lambda anim, val, obj=obj: obj.set_y(val))
 ```

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The callback will receive a Blob which can be casted to the dict in the last arg
 
 As long as the convention above is followed, the lvgl Micropython binding script would automatically set and use `user_data` when callbacks are set and used.
 
-From the user perspective, any python callable object (such as python regular function, class function, lambda etc.) can be used as an lvgl callbacks. For example:
+From the user perspective, any python callable object (such as python regular function, class function, lambda etc.) can be use as an lvgl callbacks. For example:
 ```python
 lvgl.anim_set_custom_exec_cb(anim, lambda anim, val, obj=obj: obj.set_y(val))
 ```


### PR DESCRIPTION
d7a5de4e2fd70f5d39dbff8b81328567de266251 is the parent of this. I want to use that one instead. How can I remove the second change? It should say 'used'.

So, no to 9e856cd71f601f137cf43986fb4b0f8116e18f6f
and, yes to d7a5de4e2fd70f5d39dbff8b81328567de266251

Please and thank you!
I'm just learning both git and lvgl+upy. So I'll be going through a lot of the docs and will look for more typos etc.