### PR TITLE
Update LVGL and display drivers

### DIFF
--- a/driver/generic/st77xx.py
+++ b/driver/generic/st77xx.py
@@ -459,10 +459,10 @@ class St77xx_lvgl(object):
         
         # attach all to self to avoid objects' refcount dropping to zero when the scope is exited
         self.disp_drv = lv.disp_create(self.width, self.height)
-        self.disp_drv.set_flush_cb(self.disp_drv_flush_cb)
+        self.disp_drv.set_color_format(color_format)
         self.disp_drv.set_draw_buffers(draw_buf1, draw_buf2)
         self.disp_drv.set_render_mode(lv.DISPLAY_RENDER_MODE.PARTIAL)
-        self.disp_drv.set_color_format(color_format)
+        self.disp_drv.set_flush_cb(self.disp_drv_flush_cb)
 
 class St7735(St7735_hw,St77xx_lvgl):
     def __init__(self,res,doublebuffer=True,factor=4,**kw):

--- a/examples/example1.py
+++ b/examples/example1.py
@@ -39,7 +39,7 @@ class driver:
 
         hres = 480
         vres = 272
-        color_format = lv.COLOR_FORMAT.XRGB8888
+        color_format = lv.COLOR_FORMAT.RGB8888
 
         # Register display driver
         event_loop = lv_utils.event_loop()
@@ -47,18 +47,11 @@ class driver:
         
         buf1 = lcd.framebuffer(1)
         buf2 = lcd.framebuffer(2)
-        draw_buf1 = lv.draw_buf_t()
-        draw_buf2 = lv.draw_buf_t()
-        if draw_buf1.init(hres, vres, color_format, 0, buf1, len(buf1)) != lv.RESULT.OK:
-            raise RuntimeError("Draw buffer 1 initialization failed")
-        if draw_buf2.init(hres, vres, color_format, 0, buf2, len(buf2)) != lv.RESULT.OK:
-            raise RuntimeError("Draw buffer 2 initialization failed")
         
         self.disp_drv = lv.disp_create(hres, vres)
         self.disp_drv.set_flush_cb(lcd.flush)
         self.disp_drv.set_color_format(color_format)
-        self.disp_drv.set_draw_buffers(draw_buf1, draw_buf2)
-        self.disp_drv.set_render_mode(lv.DISPLAY_RENDER_MODE.PARTIAL)
+        self.disp_drv.set_buffers(buf1, buf2, len(buf1), lv.DISPLAY_RENDER_MODE.PARTIAL)
 
         # disp_drv.gpu_blend_cb = lcd.gpu_blend
         # disp_drv.gpu_fill_cb = lcd.gpu_fill

--- a/examples/example3.py
+++ b/examples/example3.py
@@ -10,7 +10,7 @@ try:
 
     hres = 480
     vres = 272
-    color_format = lv.COLOR_FORMAT.XRGB8888
+    color_format = lv.COLOR_FORMAT.ARGB8888
 
     lv.init()
     event_loop = lv_utils.event_loop()
@@ -18,18 +18,11 @@ try:
 
     buf1 = lcd.framebuffer(1)
     buf2 = lcd.framebuffer(2)
-    draw_buf1 = lv.draw_buf_t()
-    draw_buf2 = lv.draw_buf_t()
-    if draw_buf1.init(hres, vres, color_format, 0, buf1, len(buf1)) != lv.RESULT.OK:
-        raise RuntimeError("Draw buffer 1 initialization failed")
-    if draw_buf2.init(hres, vres, color_format, 0, buf2, len(buf2)) != lv.RESULT.OK:
-        raise RuntimeError("Draw buffer 2 initialization failed")
     
     disp_drv = lv.disp_create(hres, vres)
     disp_drv.set_flush_cb(lcd.flush)
     disp_drv.set_color_format(color_format)
-    disp_drv.set_draw_buffers(draw_buf1, draw_buf2)
-    disp_drv.set_render_mode(lv.DISPLAY_RENDER_MODE.PARTIAL)
+    disp_drv.set_buffers(buf1, buf2, len(buf1), lv.DISPLAY_RENDER_MODE.PARTIAL)
 
     # disp_drv.gpu_blend_cb = lcd.gpu_blend
     # disp_drv.gpu_fill_cb = lcd.gpu_fill


### PR DESCRIPTION
- Update LVGL to [#fe61f1fc](https://github.com/lvgl/lvgl/commit/fe61f1fc94526f0edb2e27fcfb7f0efef72900ac)
- Update `ili9XXX.py` driver to use `set_buffers()`
- Remove all `print()` from `ili9XXX.py` driver
- Update example files to user `set_buffers()`

Tested on M5Core2 device (ILI9342C display)