### PR TITLE
fix CI break by disabling LV_USE_LOG

### DIFF
--- a/lv_conf.h
+++ b/lv_conf.h
@@ -177,7 +177,11 @@
  *-----------*/
 
 /*Enable the log module*/
-#define LV_USE_LOG 1
+#ifdef MICROPY_LV_USE_LOG
+    #define LV_USE_LOG MICROPY_LV_USE_LOG 
+#else
+    #define LV_USE_LOG 1
+#endif
 #if LV_USE_LOG
 
     /*How important log should be added:


### PR DESCRIPTION
Micropython test needs to disable LV_USE_LOG.