### PR TITLE
fix(gen): Use LVGL JSON in CMake based builds too - RP2040 and ESP32

### DIFF
--- a/driver/stm32/STM32F7DISC/modrk043fn48h.c
+++ b/driver/stm32/STM32F7DISC/modrk043fn48h.c
@@ -144,7 +144,7 @@ void HAL_LTDC_ReloadEventCallback(LTDC_HandleTypeDef *hltdc) {
     lv_display_flush_ready(dma2d_disp_drv);
 }
 
-STATIC void mp_rk043fn48h_ts_read(struct _lv_indev_t *indev_drv, lv_indev_data_t *data) {
+STATIC void mp_rk043fn48h_ts_read(lv_indev_t *indev_drv, lv_indev_data_t *data) {
     static TS_StateTypeDef ts_state = {0};
     static int32_t lastX = 0;
     static int32_t lastY = 0;


### PR DESCRIPTION
For lvgl/lvgl#6068

- Use LVGL JSON in CMake based builds, i.e. RP2040 and ESP32.
- Use updated name for `lv_indev_t` in STM32 source file.