### PR TITLE
drivers/generic/st77xx: Support use on platforms without machine.PWM.

### DIFF
--- a/driver/generic/st77xx.py
+++ b/driver/generic/st77xx.py
@@ -196,9 +196,10 @@ class St77xx_hw(object):
 
         self.cs,self.dc,self.rst=[(machine.Pin(p,machine.Pin.OUT) if isinstance(p,int) else p) for p in (cs,dc,rst)]
         self.bl=bl
-        if isinstance(self.bl,int): self.bl=machine.PWM(machine.Pin(self.bl,machine.Pin.OUT))
-        elif isinstance(self.bl,machine.Pin): self.bl=machine.PWM(self.bl)
-        assert isinstance(self.bl,(machine.PWM,type(None)))
+        if hasattr(machine, "PWM"):
+            if isinstance(self.bl,int): self.bl=machine.PWM(machine.Pin(self.bl,machine.Pin.OUT))
+            elif isinstance(self.bl,machine.Pin): self.bl=machine.PWM(self.bl)
+            assert isinstance(self.bl,(machine.PWM,type(None)))
         self.set_backlight(10) # set some backlight
 
         self.rot=rot


### PR DESCRIPTION
The `drivers/generic/st77xx.py` driver initialises PWM to handle the backlight with dimming.
On stm32 platform there is no `machine.PWM` module so this driver fails to load at all. This PR checks and skips the PWM if missing, meaning the backlight will fall back to basic on/off control.