### PR TITLE
(fix) lvgl deinit on soft-reset

### DIFF
--- a/lv_conf.h
+++ b/lv_conf.h
@@ -306,6 +306,10 @@ extern void mp_lv_deinit_gc();
 #define LV_GC_INIT() mp_lv_init_gc()
 #define LV_GC_DEINIT() mp_lv_deinit_gc()
 
+// include lv_conf.h in "mpconfigboard.h" for this to take effect.
+extern void lv_deinit();
+#define MICROPY_PORT_DEINIT_FUNC lv_deinit()
+
 #define LV_ENABLE_GLOBAL_CUSTOM 1
 #if LV_ENABLE_GLOBAL_CUSTOM
     extern void *mp_lv_roots;


### PR DESCRIPTION
Include `lv_conf.h` in `mpconfigboard.h` so lvgl deinit is called on soft-reset, so calling `lvgl.deinit()` is no longer necessary.

This closes #343