### PR TITLE
(fix) enable LV_USE_LOG

### DIFF
--- a/gen/gen_mpy.py
+++ b/gen/gen_mpy.py
@@ -1345,6 +1345,11 @@ void *mp_lv_user_data;
 int mp_lv_roots_initialized = 0;
 int lvgl_mod_initialized = 0;
 
+void mp_lv_log_cb(lv_log_level_t level, const char * buf){
+
+    mp_printf(&mp_plat_print, buf);
+}
+
 void mp_lv_init_gc()
 {
     if (!MP_STATE_VM(mp_lv_roots_initialized)) {

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -219,8 +219,9 @@
  *-----------*/
 
 /*Enable the log module*/
+
 #ifdef MICROPY_LV_USE_LOG
-    #define LV_USE_LOG MICROPY_LV_USE_LOG 
+    #define LV_USE_LOG MICROPY_LV_USE_LOG
 #else
     #define LV_USE_LOG 0
 #endif
@@ -239,6 +240,8 @@
     /*1: Print the log with 'printf';
     *0: User need to register a callback with `lv_log_register_print_cb()`*/
     #define LV_LOG_PRINTF 0
+
+    #define LV_LOG_PRINT_CB mp_lv_log_cb
 
     /*1: Enable print timestamp;
      *0: Disable print timestamp*/

--- a/micropython.cmake
+++ b/micropython.cmake
@@ -10,6 +10,7 @@ if(ESP_PLATFORM)
     idf_build_set_property(COMPILE_DEFINITIONS "-DLV_KCONFIG_IGNORE" APPEND)
     idf_build_set_property(COMPILE_DEFINITIONS "${LV_CFLAGS}" APPEND)
     idf_build_set_property(COMPILE_OPTIONS "-Wno-unused-function" APPEND)
+    idf_build_set_property(COMPILE_OPTIONS "-Wno-format" APPEND)
     idf_build_set_property(SRCS "${LV_SRC}" APPEND)
     idf_build_set_property(INCLUDE_DIRS "${LV_INCLUDE}" APPEND)
 


### PR DESCRIPTION
Add a default callback that works for all ports if `LV_USE_LOG` is enabled