### PR TITLE
Register automatic git submodules handling

### DIFF
--- a/micropython.cmake
+++ b/micropython.cmake
@@ -1,6 +1,12 @@
 
 # This file is to be given as "make USER_C_MODULES=..." when building Micropython port
 
+if(ECHO_SUBMODULES)
+    list(APPEND GIT_SUBMODULES ${CMAKE_CURRENT_LIST_DIR}/lvgl ${CMAKE_CURRENT_LIST_DIR}/pycparser)
+elseif(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/lvgl/README.md)
+    message(FATAL_ERROR " lvgl not initialized.\n Run 'make BOARD=${MICROPY_BOARD} submodules'")
+endif()
+
 # Include LVGL component, ignore KCONFIG
 separate_arguments(LV_CFLAGS_ENV UNIX_COMMAND $ENV{LV_CFLAGS})
 

--- a/micropython.mk
+++ b/micropython.mk
@@ -105,3 +105,12 @@ SRC_USERMOD_LIB_C += $(shell find $(LVGL_DIR)/examples -type f -name "*.c")
 endif
 
 SRC_USERMOD_C += $(LVGL_MPY)
+
+# include lvgl submodule check in the micropython submodules rule.
+LVGL_SUBMODULES = lvgl pycparser
+submodules: lvgl_submodule
+lvgl_submodule:
+	$(ECHO) "Updating submodules: $(LVGL_SUBMODULES)"
+	$(Q)cd $(LVGL_BINDING_DIR) && git submodule sync $(LVGL_SUBMODULES)
+	$(Q)cd $(LVGL_BINDING_DIR) && git submodule update --init $(LVGL_SUBMODULES)
+.PHONY: lvgl_submodule

--- a/micropython.mk
+++ b/micropython.mk
@@ -100,3 +100,12 @@ SRC_USERMOD_LIB_C += $(shell find $(LVGL_DIR)/examples -type f -name "*.c")
 endif
 
 SRC_USERMOD_C += $(LVGL_MPY)
+
+# include lvgl submodule check in the micropython submodules rule.
+LVGL_SUBMODULES = lvgl pycparser
+submodules: lvgl_submodule
+lvgl_submodule:
+	$(ECHO) "Updating submodules: $(LVGL_SUBMODULES)"
+	$(Q)cd $(LVGL_BINDING_DIR) && git submodule sync $(LVGL_SUBMODULES)
+	$(Q)cd $(LVGL_BINDING_DIR) && git submodule update --init $(LVGL_SUBMODULES)
+.PHONY: lvgl_submodule


### PR DESCRIPTION
## Summary

Adds automatic submodule initialization for lvgl and pycparser to both Make and CMake build systems. This removes the manual step of running `git submodule update --init` before building. Both implementations hook into MicroPython's existing submodules target - Make appends to the target directly, while CMake registers via the ECHO_SUBMODULES mechanism. Also adds validation in CMake to catch missing submodules at configuration time with a helpful error message.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically initializes `lvgl` and `pycparser` git submodules in both Make and CMake builds to remove the manual step. CMake also fails fast with a clear error if `lvgl` isn’t initialized.

- **New Features**
  - Make: extends MicroPython’s `submodules` target to sync/init `lvgl` and `pycparser`.
  - CMake: registers both via `ECHO_SUBMODULES`; if `lvgl/README.md` is missing, configuration fails and suggests `make BOARD=${MICROPY_BOARD} submodules`.

<sup>Written for commit 40b90ad1a91106f37158bdac1ddd005378a002ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lvgl/lv_binding_micropython/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

