### PR TITLE
(feat) Add basic mimxrt support.

### DIFF
--- a/lv_conf.h
+++ b/lv_conf.h
@@ -228,7 +228,9 @@
 #endif
 
 /** Use NXP's VG-Lite GPU on iMX RTxxx platforms. */
+#ifndef LV_USE_DRAW_VGLITE
 #define LV_USE_DRAW_VGLITE 0
+#endif
 
 #if LV_USE_DRAW_VGLITE
     /** Enable blit quality degradation workaround recommended for screen's dimension > 352 pixels. */
@@ -249,7 +251,9 @@
 #endif
 
 /** Use NXP's PXP on iMX RTxxx platforms. */
+#ifndef LV_USE_PXP
 #define LV_USE_PXP 0
+#endif
 
 #if LV_USE_PXP
     /** Use PXP for drawing.*/

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -114,7 +114,9 @@
 #define LV_DRAW_BUF_STRIDE_ALIGN                1
 
 /** Align start address of draw_buf addresses to this bytes*/
+#ifndef LV_DRAW_BUF_ALIGN
 #define LV_DRAW_BUF_ALIGN                       4
+#endif
 
 /** Using matrix for transformations.
  * Requirements:
@@ -249,14 +251,20 @@
 #endif
 
 /** Use NXP's PXP on iMX RTxxx platforms. */
+#ifndef LV_USE_PXP
 #define LV_USE_PXP 0
+#endif
 
 #if LV_USE_PXP
     /** Use PXP for drawing.*/
+    #ifndef LV_USE_DRAW_PXP
     #define LV_USE_DRAW_PXP 1
+    #endif
 
     /** Use PXP to rotate display.*/
+    #ifndef LV_USE_ROTATE_PXP
     #define LV_USE_ROTATE_PXP 0
+    #endif
 
     #if LV_USE_DRAW_PXP && LV_USE_OS
         /** Use additional draw thread for PXP processing.*/

--- a/micropython.mk
+++ b/micropython.mk
@@ -1,9 +1,12 @@
+################################################################################
+# LVGL port Support
+MICROPY_PORT = $(notdir $(CURDIR))
 
+ifeq ($(MICROPY_PORT),unix)
 ################################################################################
 # LVGL unix optional libraries
 # Update CFLAGS_USERMOD and LDFLAGS_USERMOD for LVGL extenral library,
 # but do that only on the unix port, for unix specific dependencies
-ifeq ($(notdir $(CURDIR)),unix)
 ifneq ($(UNAME_S),Darwin)
 CFLAGS_USERMOD += -DMICROPY_FB=1
 endif
@@ -15,7 +18,7 @@ CFLAGS_USERMOD += $(SDL_CFLAGS_USERMOD) -DMICROPY_SDL=1
 LDFLAGS_USERMOD += $(SDL_LDFLAGS_USERMOD)
 endif
 
-# Avoid including unwanted local headers other than sdl2 
+# Avoid including unwanted local headers other than sdl2
 ifeq ($(UNAME_S),Darwin)
 CFLAGS_USERMOD:=$(filter-out -I/usr/local/include,$(CFLAGS_USERMOD))
 endif
@@ -43,7 +46,22 @@ endif
 # LDFLAGS_USERMOD += $(FFMPEG_LDFLAGS_USERMOD)
 # endif
 
-endif
+endif # unix support
+
+ifeq ($(MICROPY_PORT),mimxrt)
+CFLAGS_USERMOD += -DLV_USE_PXP=1 -DLV_USE_DRAW_PXP=1 -DLV_USE_GPU_NXP_PXP=1 -DLV_USE_GPU_NXP_PXP_AUTO_INIT=1
+
+# Depending on how the USER_C_MODULE is declared the object files inside build can be based on
+# absolute or relative paths under this directory.
+MOD_ABSPATH := $(abspath $(USERMOD_DIR))
+MOD_DIRNAME := $(notdir $(MOD_ABSPATH))
+$(BUILD)/$(MOD_ABSPATH)/lvgl/src/draw/nxp/pxp/lv_draw_pxp.o: CFLAGS_USERMOD += -Wno-error=unused-variable
+$(BUILD)/$(MOD_DIRNAME)/lvgl/src/draw/nxp/pxp/lv_draw_pxp.o: CFLAGS_USERMOD += -Wno-error=unused-variable
+$(BUILD)/$(MOD_ABSPATH)/lvgl/src/draw/nxp/pxp/lv_draw_pxp_img.o: CFLAGS_USERMOD += -Wno-error=float-conversion
+$(BUILD)/$(MOD_DIRNAME)/lvgl/src/draw/nxp/pxp/lv_draw_pxp_img.o: CFLAGS_USERMOD += -Wno-error=float-conversion
+
+endif # mimxrt support
+
 
 ################################################################################
 
@@ -76,7 +94,7 @@ CFLAGS_USERMOD += -DLV_CONF_PATH='"$(LV_CONF_PATH)"'
 # CFLAGS DEBUG
 $(info CFLAGS_USERMOD is $(CFLAGS_USERMOD))
 
-$(LVGL_MPY): $(ALL_LVGL_SRC) $(LVGL_BINDING_DIR)/gen/gen_mpy.py 
+$(LVGL_MPY): $(ALL_LVGL_SRC) $(LVGL_BINDING_DIR)/gen/gen_mpy.py
 	$(ECHO) "LVGL-GEN $@"
 	$(Q)mkdir -p $(dir $@)
 	$(Q)$(CPP) $(CFLAGS_USERMOD) -DPYCPARSER -x c -I $(LVGL_BINDING_DIR)/pycparser/utils/fake_libc_include $(INC) $(LVGL_DIR)/lvgl.h > $(LVGL_PP)

--- a/micropython.mk
+++ b/micropython.mk
@@ -1,9 +1,13 @@
 
 ################################################################################
+# LVGL port Support
+MICROPY_PORT = $(notdir $(CURDIR))
+
+ifeq ($(MICROPY_PORT),unix)
+################################################################################
 # LVGL unix optional libraries
 # Update CFLAGS_USERMOD and LDFLAGS_USERMOD for LVGL extenral library,
 # but do that only on the unix port, for unix specific dependencies
-ifeq ($(notdir $(CURDIR)),unix)
 ifneq ($(UNAME_S),Darwin)
 CFLAGS_USERMOD += -DMICROPY_FB=1
 endif
@@ -43,7 +47,21 @@ endif
 # LDFLAGS_USERMOD += $(FFMPEG_LDFLAGS_USERMOD)
 # endif
 
-endif
+endif # unix support
+
+ifeq ($(MICROPY_PORT),mimxrt)
+CFLAGS_USERMOD += -DLV_USE_PXP=1 -DLV_USE_DRAW_PXP=1 -DLV_USE_GPU_NXP_PXP=1 -DLV_USE_GPU_NXP_PXP_AUTO_INIT=1
+
+# Depending on how the USER_C_MODULE is declared the object files inside build can be based on
+# absolute or relative paths under this directory.
+MOD_ABSPATH := $(abspath $(USERMOD_DIR))
+MOD_DIRNAME := $(notdir $(MOD_ABSPATH))
+$(BUILD)/$(MOD_ABSPATH)/lvgl/src/draw/nxp/pxp/lv_draw_pxp.o: CFLAGS_USERMOD += -Wno-error=unused-variable
+$(BUILD)/$(MOD_DIRNAME)/lvgl/src/draw/nxp/pxp/lv_draw_pxp.o: CFLAGS_USERMOD += -Wno-error=unused-variable
+$(BUILD)/$(MOD_ABSPATH)/lvgl/src/draw/nxp/pxp/lv_draw_pxp_img.o: CFLAGS_USERMOD += -Wno-error=float-conversion
+$(BUILD)/$(MOD_DIRNAME)/lvgl/src/draw/nxp/pxp/lv_draw_pxp_img.o: CFLAGS_USERMOD += -Wno-error=float-conversion
+
+endif # mimxrt support
 
 ################################################################################
 


### PR DESCRIPTION
I'm working on getting LVGL working cleanly on the NXP 1170 EVK with a LVGL v9 compatible driver in progress here: https://github.com/andrewleech/imxrt1170_display_driver

These minimal changes to the LVGL bindings files enables the build environment to enable port specific features more easily.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add basic NXP i.MX RT (mimxrt) support with PXP acceleration and port-aware build rules. LVGL v9 now runs on the RT1170 EVK with PXP.

- **New Features**
  - Detect the active port in `micropython.mk`; add a `mimxrt` block that sets `LV_USE_PXP`, `LV_USE_DRAW_PXP`, `LV_USE_GPU_NXP_PXP`, and `LV_USE_GPU_NXP_PXP_AUTO_INIT` via `CFLAGS_USERMOD`, and silences specific PXP driver warnings for a clean `-Werror` build.
  - Guard `LV_DRAW_BUF_ALIGN`, `LV_USE_PXP`, `LV_USE_DRAW_PXP`, and `LV_USE_ROTATE_PXP` with `#ifndef` in `lv_conf.h` so boards can override via build flags without redefinition warnings.
  - Add a `submodules` rule to initialize `lvgl` and `pycparser` from the port build with `make submodules`.

<sup>Written for commit 9a2fffa1921093ae381d648234396e0833be7e48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lvgl/lv_binding_micropython/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

