### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 [![MicroPython-LVGL CI](https://github.com/lvgl/lv_binding_micropython/actions/workflows/micropython_lvgl_ci.yml/badge.svg)](https://github.com/lvgl/lv_binding_micropython/actions/workflows/micropython_lvgl_ci.yml)
 
+> [!WARNING]
+> Building this firmware for Esp32 devices currently fails due to this [issue](https://github.com/lvgl/lv_binding_micropython/issues/372).
+
+
+
+
 # Bindings for LVGL
 
 ---


### PR DESCRIPTION
Added warning that build for Esp32 versions fails.

This short info would have saved me and probably many others a lot of time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a README warning that ESP32 firmware builds currently fail due to issue #372. This helps users avoid spending time on a broken target until the issue is resolved.

<sup>Written for commit e208c75cfc938a0edafc274e566d4030226455c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

