### PR TITLE
Various code fixes to allow stricter warn flags

### DIFF
--- a/gen/gen_mpy.py
+++ b/gen/gen_mpy.py
@@ -1026,7 +1026,7 @@ typedef struct mp_lv_obj_type_t {{
 static const mp_lv_obj_type_t mp_lv_{base_obj}_type;
 static const mp_lv_obj_type_t *mp_lv_obj_types[];
 
-static inline const mp_obj_type_t *get_BaseObj_type()
+static inline const mp_obj_type_t *get_BaseObj_type(void)
 {{
     return mp_lv_{base_obj}_type.mp_obj_type;
 }}
@@ -1214,7 +1214,7 @@ static inline LV_OBJ_T *mp_get_callbacks(mp_obj_t mp_obj)
     return mp_lv_obj->callbacks;
 }
 
-static inline const mp_obj_type_t *get_BaseObj_type();
+static inline const mp_obj_type_t *get_BaseObj_type(void);
 
 static void mp_lv_delete_cb(lv_event_t * e)
 {
@@ -1345,12 +1345,15 @@ void *mp_lv_user_data;
 int mp_lv_roots_initialized = 0;
 int lvgl_mod_initialized = 0;
 
+/* Prototype definition to make -Werror=missing-prototype happy */
+void mp_lv_log_cb(lv_log_level_t level, const char * buf);
+
 void mp_lv_log_cb(lv_log_level_t level, const char * buf){
 
     mp_printf(&mp_plat_print, buf);
 }
 
-void mp_lv_init_gc()
+void mp_lv_init_gc(void)
 {
     if (!MP_STATE_VM(mp_lv_roots_initialized)) {
         // mp_printf(&mp_plat_print, "[ INIT GC ]");
@@ -1359,7 +1362,7 @@ void mp_lv_init_gc()
     }
 }
 
-void mp_lv_deinit_gc()
+void mp_lv_deinit_gc(void)
 {
 
     // mp_printf(&mp_plat_print, "[ DEINIT GC ]");
@@ -2427,7 +2430,7 @@ def try_generate_struct(struct_name, struct):
  * Struct {struct_name}
  */
 
-static inline const mp_obj_type_t *get_mp_{sanitized_struct_name}_type();
+static inline const mp_obj_type_t *get_mp_{sanitized_struct_name}_type(void);
 
 static inline void* mp_write_ptr_{sanitized_struct_name}(mp_obj_t self_in)
 {{
@@ -2495,7 +2498,7 @@ static MP_DEFINE_CONST_OBJ_TYPE(
     parent, &mp_lv_base_struct_type
 );
 
-static inline const mp_obj_type_t *get_mp_{sanitized_struct_name}_type()
+static inline const mp_obj_type_t *get_mp_{sanitized_struct_name}_type(void)
 {{
     return &mp_{sanitized_struct_name}_type;
 }}

--- a/gen/gen_mpy.py
+++ b/gen/gen_mpy.py
@@ -1235,10 +1235,10 @@ static inline mp_obj_t lv_to_mp(LV_OBJ_T *lv_obj)
     {
         // Find the object type
         const mp_obj_type_t *mp_obj_type = get_BaseObj_type();
-        const lv_obj_class_t *lv_obj_class = lv_obj_get_class(lv_obj);
+        const lv_obj_class_t *lv_obj_cls = lv_obj_get_class(lv_obj);
         const mp_lv_obj_type_t **iter = &mp_lv_obj_types[0];
         for (; *iter; iter++) {
-            if ((*iter)->lv_obj_class == lv_obj_class) {
+            if ((*iter)->lv_obj_class == lv_obj_cls) {
                 mp_obj_type = (*iter)->mp_obj_type;
                 break;
             }

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -429,8 +429,8 @@
 
 /*Garbage Collector settings
  *Used if LVGL is bound to higher level language and the memory is managed by that language*/
-extern void mp_lv_init_gc();
-extern void mp_lv_deinit_gc();
+extern void mp_lv_init_gc(void);
+extern void mp_lv_deinit_gc(void);
 #define LV_GC_INIT() mp_lv_init_gc()
 #define LV_GC_DEINIT() mp_lv_deinit_gc()
 


### PR DESCRIPTION
When I tried to compile this with CircuitPython (MP fork), I encountered a lot of compilation errors, notably due to missing `void` in function prototypes and declarations when those take no arguments.

This PR addresses that.

---
### Error summary

Encountered a few thousand times in generated `lv_mpy.c`:
```
build/lvgl/lv_mpy.c: In function 'get_mp_lv_event_dsc_t_type':
build/lvgl/lv_mpy.c:13923:36: error: old-style function definition [-Werror=old-style-definition]
13923 | static inline const mp_obj_type_t *get_mp_lv_event_dsc_t_type()
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated due to -fmax-errors=50.
```

Strict/missing prototypes:
```
In file included from user_modules/lvgl_mpy/lvgl/src/lv_conf_internal.h:56,
                 from user_modules/lvgl_mpy/lvgl/src/lv_init.h:16,
                 from user_modules/lvgl_mpy/lvgl/lvgl.h:21,
                 from build/lvgl/lv_mpy.c:33:
user_modules/lvgl_mpy/lv_conf.h:432:1: error: function declaration isn't a prototype [-Werror=strict-prototypes]
  432 | extern void mp_lv_init_gc();
      | ^~~~~~
user_modules/lvgl_mpy/lv_conf.h:433:1: error: function declaration isn't a prototype [-Werror=strict-prototypes]
  433 | extern void mp_lv_deinit_gc();
      | ^~~~~~
build/lvgl/lv_mpy.c: At top level:
build/lvgl/lv_mpy.c:359:6: error: no previous prototype for 'mp_lv_log_cb' [-Werror=missing-prototypes]
  359 | void mp_lv_log_cb(lv_log_level_t level, const char * buf){
      |      ^~~~~~~~~~~~
build/lvgl/lv_mpy.c:364:6: error: no previous prototype for 'mp_lv_init_gc' [-Werror=missing-prototypes]
  364 | void mp_lv_init_gc(void)
      |      ^~~~~~~~~~~~~
build/lvgl/lv_mpy.c:373:6: error: no previous prototype for 'mp_lv_deinit_gc' [-Werror=missing-prototypes]
  373 | void mp_lv_deinit_gc(void)
      |      ^~~~~~~~~~~~~~~
build/lvgl/lv_mpy.c: In function 'mp_mp_lv_init_gc':
build/lvgl/lv_mpy.c:41561:5: error: function declaration isn't a prototype [-Werror=strict-prototypes]
41561 |     ((void (*)())lv_func_ptr)();
      |     ^
```

Shadowed variable:
```
build/lvgl/lv_mpy.c: In function 'lv_to_mp':
build/lvgl/lv_mpy.c:249:31: error: declaration of 'lv_obj_class' shadows a global declaration [-Werror=shadow]
  249 |         const lv_obj_class_t *lv_obj_class = lv_obj_get_class(lv_obj);
      |                               ^~~~~~~~~~~~
In file included from user_modules/lvgl_mpy/lvgl/lvgl.h:43:
user_modules/lvgl_mpy/lvgl/src/core/lv_obj.h:218:54: note: shadowed declaration is here
  218 | LV_ATTRIBUTE_EXTERN_DATA extern const lv_obj_class_t lv_obj_class;
      |                                                      ^~~~~~~~~~~~
```
